### PR TITLE
Add experimental Windows support (v1.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run [Claude Code](https://claude.com/claude-code) in your Obsidian sidebar.
 
 ## Requirements
 
-- macOS or Linux
+- macOS, Linux, or Windows
 - Python 3
 - [Claude Code](https://claude.com/claude-code)
 
@@ -66,16 +66,34 @@ Then restart Obsidian or disable/re-enable the plugin.
 |----------|--------|
 | macOS | ✅ Supported |
 | Linux | ✅ Supported |
-| Windows | ❌ Not supported |
+| Windows | ⚠️ Experimental |
+
+### Windows Setup (Experimental)
+
+Windows requires additional dependencies:
+
+1. Install Python 3 from [python.org](https://python.org)
+2. Install pywinpty:
+```bash
+pip install pywinpty
+```
+
+3. Install the plugin (run from your vault folder in PowerShell):
+```powershell
+$u="https://github.com/derek-larson14/obsidian-claude-sidebar/archive/main.zip"; Invoke-WebRequest $u -OutFile s.zip; Expand-Archive s.zip .obsidian\plugins -Force; Move-Item ".obsidian\plugins\obsidian-claude-sidebar-main" ".obsidian\plugins\claude-sidebar" -Force; Remove-Item s.zip
+```
+
+**Note:** Windows support is experimental. Performance may be slower than macOS/Linux due to ConPTY overhead.
 
 ## How It Works
 
 - [xterm.js](https://xtermjs.org/) for terminal emulation
-- Python's built-in `pty` module for pseudo-terminal support
+- Python's built-in `pty` module for pseudo-terminal support (macOS/Linux)
+- [pywinpty](https://github.com/andfoy/pywinpty) for Windows PTY support
 
 ## Development
 
-The PTY script (`terminal_pty.py`) is embedded as base64 in `main.js` for Obsidian plugin directory compatibility. To rebuild after modifying the Python:
+The PTY scripts (`terminal_pty.py` for Unix, `terminal_win.py` for Windows) are embedded as base64 in `main.js` for Obsidian plugin directory compatibility. To rebuild after modifying:
 
 ```bash
 ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
-# Embeds terminal_pty.py into main.js as base64
-# Run this after modifying terminal_pty.py
+# Embeds terminal_pty.py and terminal_win.py into main.js as base64
+# Run this after modifying the PTY scripts
 
 set -e
 
-PYTHON_FILE="terminal_pty.py"
 JS_FILE="main.js"
 
-if [ ! -f "$PYTHON_FILE" ]; then
-    echo "Error: $PYTHON_FILE not found"
-    exit 1
+# Unix PTY script
+if [ -f "terminal_pty.py" ]; then
+    B64=$(base64 -i "terminal_pty.py" | tr -d '\n')
+    sed -i '' "s|PTY_SCRIPT_B64 = \"[^\"]*\"|PTY_SCRIPT_B64 = \"$B64\"|" "$JS_FILE"
+    echo "✓ Embedded terminal_pty.py into $JS_FILE"
+else
+    echo "Warning: terminal_pty.py not found"
 fi
 
-# Base64 encode (single line)
-B64=$(base64 -i "$PYTHON_FILE" | tr -d '\n')
-
-# Replace the PTY_SCRIPT_B64 value in main.js
-sed -i '' "s|PTY_SCRIPT_B64 = \"[^\"]*\"|PTY_SCRIPT_B64 = \"$B64\"|" "$JS_FILE"
-
-echo "✓ Embedded $PYTHON_FILE into $JS_FILE"
+# Windows PTY script
+if [ -f "terminal_win.py" ]; then
+    WIN_B64=$(base64 -i "terminal_win.py" | tr -d '\n')
+    sed -i '' "s|WIN_PTY_SCRIPT_B64 = \"[^\"]*\"|WIN_PTY_SCRIPT_B64 = \"$WIN_B64\"|" "$JS_FILE"
+    echo "✓ Embedded terminal_win.py into $JS_FILE"
+else
+    echo "Warning: terminal_win.py not found (Windows support disabled)"
+fi

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "claude-sidebar",
 	"name": "Claude Sidebar",
-	"version": "1.4.2",
+	"version": "1.5.0",
 	"minAppVersion": "1.0.0",
 	"description": "Run Claude Code in your sidebar.",
 	"author": "Derek Larson",

--- a/terminal_win.py
+++ b/terminal_win.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Windows terminal wrapper using ConPTY via pywinpty."""
+import sys
+import re
+import threading
+
+# Pre-compile regex patterns for performance
+RESIZE_RE = re.compile(rb'\x1b\]RESIZE;[0-9]+;[0-9]+\x07', re.IGNORECASE)
+FOCUS_IN_RE = re.compile(rb'\x1b\[I')
+FOCUS_OUT_RE = re.compile(rb'\x1b\[O')
+
+def main():
+    # Parse args: terminal_win.py [cols] [rows] [shell]
+    if len(sys.argv) < 4:
+        print(f"Usage: {sys.argv[0]} cols rows shell", file=sys.stderr)
+        sys.exit(1)
+
+    cols = int(sys.argv[1])
+    rows = int(sys.argv[2])
+    shell = sys.argv[3]
+
+    # pywinpty is required for Windows PTY support
+    try:
+        from winpty import PTY
+    except ImportError:
+        print("pywinpty not installed. Run: pip install pywinpty", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        pty = PTY(cols, rows)
+        pty.spawn(shell)
+
+        running = True
+
+        def read_output():
+            nonlocal running
+            while running and pty.isalive():
+                try:
+                    data = pty.read()
+                    if data:
+                        # pywinpty returns strings
+                        output = data.encode('utf-8') if isinstance(data, str) else data
+                        # Filter out escape sequences that get echoed back
+                        output = RESIZE_RE.sub(b'', output)
+                        output = FOCUS_IN_RE.sub(b'', output)
+                        output = FOCUS_OUT_RE.sub(b'', output)
+                        if output:
+                            sys.stdout.buffer.write(output)
+                            sys.stdout.buffer.flush()
+                except Exception:
+                    pass
+            running = False
+
+        output_thread = threading.Thread(target=read_output, daemon=True)
+        output_thread.start()
+
+        while running and pty.isalive():
+            try:
+                data = sys.stdin.buffer.read(1)
+                if not data:
+                    break
+                # Check for resize escape sequence
+                if data == b'\x1b':
+                    peek = sys.stdin.buffer.read(7)
+                    if peek == b']RESIZE':
+                        # Read until \x07
+                        resize_data = b''
+                        while True:
+                            c = sys.stdin.buffer.read(1)
+                            if c == b'\x07':
+                                break
+                            resize_data += c
+                        # Parse ;cols;rows
+                        parts = resize_data.decode().strip(';').split(';')
+                        if len(parts) == 2:
+                            try:
+                                new_cols, new_rows = int(parts[0]), int(parts[1])
+                                pty.set_size(new_cols, new_rows)
+                            except ValueError:
+                                pass
+                    else:
+                        pty.write((data + peek).decode('utf-8', errors='replace'))
+                else:
+                    pty.write(data.decode('utf-8', errors='replace'))
+            except Exception:
+                break
+
+        running = False
+        sys.exit(0)
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Add Windows PTY support via pywinpty
- Filter focus/resize escape sequences to prevent terminal noise
- Add Windows-friendly fonts (Cascadia Mono, Consolas)
- Platform-specific shell detection (cmd.exe on Windows)
- Update build.sh to embed both Unix and Windows PTY scripts
- Update README with Windows setup instructions

Windows requires: Python 3, pywinpty

🤖 Generated with [Claude Code](https://claude.com/claude-code)