### PR TITLE
Simplify scroll handling to fix freezing

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "claude-sidebar",
 	"name": "Claude Sidebar",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"minAppVersion": "1.0.0",
 	"description": "Run Claude Code in your sidebar.",
 	"author": "Derek Larson",


### PR DESCRIPTION
- Remove scroll state tracking (userScrolled, pendingFit)
- Remove setupViewportScrollTracking, setupFocusTracking
- Remove updateScrollState, isAtBottom, maybeAutoScroll, isTerminalActive
- Simplify fit() to just call fitAddon.fit()
- Increase debounce from 50ms to 100ms
- Only update theme if colors actually changed
- Trust xterm.js to handle scroll position naturally

Fixes intermittent sidebar freezing caused by scroll→fit→scroll loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)