### PR TITLE
v1.5.2: Direct Claude launch for cleaner startup UX

### DIFF
--- a/main.js
+++ b/main.js
@@ -7119,7 +7119,7 @@ var TerminalView = class extends import_obsidian.ItemView {
     let cmd = isWindows ? "python" : "python3";
     let args = isWindows
       ? [ptyPath, String(cols), String(rows), shell]
-      : [ptyPath, String(cols), String(rows), shell, "-i"];
+      : [ptyPath, String(cols), String(rows), shell, "-lc", "claude || true; exec $SHELL -i"];
     this.proc = (0, import_child_process.spawn)(cmd, args, {
       cwd,
       env: { ...process.env, TERM: "xterm-256color" },
@@ -7160,18 +7160,14 @@ var TerminalView = class extends import_obsidian.ItemView {
       }
     });
     this.term?.focus();
-    // Auto-launch Claude Code after shell initializes
-    // Windows needs longer delay for ConPTY to settle
-    const launchDelay = process.platform === "win32" ? 1000 : 300;
-    setTimeout(() => {
-      if (this.proc && !this.proc.killed) {
-        this.proc.stdin?.write('claude\r');
-      }
-    }, launchDelay);
-    // Focus again after Claude Code has time to start
-    setTimeout(() => {
-      this.term?.focus();
-    }, 2000);
+    // Windows still needs auto-launch since we can't use exec there
+    if (isWindows) {
+      setTimeout(() => {
+        if (this.proc && !this.proc.killed) {
+          this.proc.stdin?.write('claude\r');
+        }
+      }, 1000);
+    }
   }
   stopShell() {
     if (this.proc && !this.proc.killed) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "claude-sidebar",
 	"name": "Claude Sidebar",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"minAppVersion": "1.0.0",
 	"description": "Run Claude Code in your sidebar.",
 	"author": "Derek Larson",


### PR DESCRIPTION
## Summary
- Launch Claude directly via shell `-lc` command (no prompt flash before Claude starts)
- Remove 300ms startup delay on Mac/Linux (faster startup)
- Drop to user's shell after exiting Claude (Ctrl+C twice gives you a shell)
- Keep simplified `fit()` without internal xterm API dependencies

## Test plan
- [x] Open new Claude tab - should start clean without prompt flash
- [x] Ctrl+C twice to exit Claude - should drop to shell
- [x] Type `claude` in shell to restart
- [x] Resize sidebar - no scroll/freeze issues
- [x] Windows still works (uses old auto-type approach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)