### PR TITLE
Add image paste support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "claude-sidebar",
 	"name": "Claude Sidebar",
-	"version": "1.5.5",
+	"version": "1.5.6",
 	"minAppVersion": "1.0.0",
 	"description": "Run Claude Code in your sidebar.",
 	"author": "Derek Larson",


### PR DESCRIPTION
Pasting images now saves them to a temp file and inserts the path into the terminal. Claude CLI natively supports image files by path.