### PR TITLE
Fix auto-focus terminal input when opening new tab

### DIFF
--- a/main.js
+++ b/main.js
@@ -7370,6 +7370,13 @@ var VaultTerminalPlugin = class extends import_obsidian.Plugin {
     if (leaf) {
       await leaf.setViewState({ type: VIEW_TYPE, active: true });
       this.app.workspace.revealLeaf(leaf);
+      // Focus the terminal after the leaf is revealed
+      setTimeout(() => {
+        const view = leaf.view;
+        if (view instanceof TerminalView && view.term) {
+          view.term.focus();
+        }
+      }, 50);
     }
   }
 };

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "claude-sidebar",
 	"name": "Claude Sidebar",
-	"version": "1.5.7",
+	"version": "1.5.8",
 	"minAppVersion": "1.0.0",
 	"description": "Run Claude Code in your sidebar.",
 	"author": "Derek Larson",


### PR DESCRIPTION
Focus was being lost because it happened during setViewState before the leaf was fully revealed. Added a small delay after revealLeaf to ensure focus happens after the UI settles.