### PR TITLE
Fix Option+key not producing characters in Electron for international keyboards

### DIFF
--- a/main.js
+++ b/main.js
@@ -7259,8 +7259,17 @@ var TerminalView = class extends import_obsidian.ItemView {
         return false; // Block both keydown and keypress
       }
       if (ev.type === 'keydown') {
-        // macOS: let Option+key through for international keyboard layouts (e.g. Opt+Q = @ on Spanish)
+        // macOS: Option+key produces special characters on international keyboards (e.g. Opt+Q = @ on Spanish)
+        // xterm's _isThirdLevelShift relies on keypress events which may not fire in Electron,
+        // so we intercept the keydown and write the OS-transformed character directly.
         if (process.platform === 'darwin' && ev.altKey && !ev.metaKey && !ev.ctrlKey) {
+          if (ev.key && ev.key.length === 1) {
+            ev.preventDefault();
+            if (this.proc && !this.proc.killed) {
+              this.proc.stdin?.write(ev.key);
+            }
+            return false;
+          }
           return true;
         }
         // Windows Ctrl+V: paste from clipboard (Obsidian intercepts this before xterm sees it)


### PR DESCRIPTION
## Summary
- Fixes Option+key combinations not producing special characters in the terminal sidebar on macOS (e.g., Opt+Q = @ on Spanish/German keyboards)
- The previous fix (#56, `macOptionIsMeta: false` + returning `true` from `customKeyEventHandler`) relied on xterm's `_isThirdLevelShift` mechanism, which depends on `keypress` events. In Electron (Obsidian's runtime), `keypress` events don't fire reliably for Option+key combinations
- Instead of letting xterm handle it, we now intercept the `keydown` event, extract the OS-transformed character from `ev.key`, and write it directly to the shell process via `proc.stdin`

## How it works
When Option+key is pressed on macOS and produces a single printable character (`ev.key.length === 1`):
1. `preventDefault()` suppresses the unreliable `keypress` event
2. `ev.key` (which contains the OS-transformed character, e.g. `@`) is written directly to the shell
3. Returns `false` to tell xterm not to process the event

For Option+key combos that don't produce a single character (dead keys, Option+Arrow for word navigation), the fallback `return true` lets xterm handle them normally.

## Test plan
- [ ] On a Spanish/German/other international macOS keyboard layout, press Opt+Q in the plugin sidebar — should produce `@`
- [ ] Other Option+key special characters should work (e.g., Opt+2 = €, Opt+E = ´)
- [ ] Option+Arrow keys still work for word navigation
- [ ] Dead keys (e.g., Opt+E then a vowel for accents) still work
- [ ] No regression on US keyboard layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)