### PR TITLE
Fix: call super.setState() in TerminalView

### DIFF
--- a/main.js
+++ b/main.js
@@ -6792,6 +6792,7 @@ var TerminalView = class extends import_obsidian.ItemView {
   }
   // Obsidian calls setState() with custom state from setViewState()
   async setState(state, result) {
+    await super.setState(state, result);
     if (state?.workingDir) {
       this.workingDir = state.workingDir;
     }


### PR DESCRIPTION
## Summary

- `TerminalView.setState()` was not calling `await super.setState(state, result)`, skipping Obsidian's `ItemView` state initialization
- The parent class processes the `result` parameter that Obsidian's workspace restoration relies on
- Without it, workspace history navigation may not work correctly for Claude tabs, and future Obsidian versions could hit undefined reference errors during state hydration

## Change

One line added at the top of `setState()`:

```js
async setState(state, result) {
    await super.setState(state, result); // ← added
    if (state?.workingDir) {
```

## Test plan

- [x] Open vault with Claude tab in workspace, close and reopen Obsidian — tab restores without error
- [x] Open Claude tab, navigate away and back with workspace history — state preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)