### PR TITLE
Add GitHub Copilot CLI as a backend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Built by [Derek Larson](https://dtlarson.com). [Pair with commands →](https://
 - **Multiple tabs** - Run multiple Claude instances side by side
 - **Folder context menu** - Right-click any folder to open Claude in that directory
 - **YOLO mode** - Launch Claude with `--dangerously-skip-permissions` via right-click menus
-- **Multi-backend** - Switch between Claude Code, Codex, OpenCode, and Gemini CLI in settings
+- **Multi-backend** - Switch between Claude Code, Codex, OpenCode, Gemini CLI, Kimi Code, and GitHub Copilot CLI in settings
 
 ## Requirements
 

--- a/main.js
+++ b/main.js
@@ -6747,6 +6747,14 @@ var CLI_BACKENDS = {
     resumeFlag: "--continue",
     resumeIsSubcommand: false,
   },
+  copilot: {
+    label: "GitHub Copilot CLI",
+    binary: "copilot",
+    pathHints: ["/opt/homebrew/bin"],
+    yoloFlag: "--allow-all",
+    resumeFlag: "--continue",
+    resumeIsSubcommand: false,
+  },
 };
 var TerminalView = class extends import_obsidian.ItemView {
   constructor(leaf, plugin) {


### PR DESCRIPTION
## Summary

Adds GitHub Copilot CLI to the CLI backend dropdown alongside Claude Code, Codex, OpenCode, Gemini CLI, and Kimi Code.

## Details

Uses the same `CLI_BACKENDS` descriptor pattern as the existing entries:

| Field | Value |
|---|---|
| Binary | `copilot` |
| YOLO flag | `--allow-all` (equivalent to `--allow-all-tools --allow-all-paths --allow-all-urls`) |
| Resume flag | `--continue` |
| pathHints | `/opt/homebrew/bin` (for Homebrew npm installs) |

Path resolution behavior matches the other backends: macOS/Linux pull PATH from the user's login shell and prepend `pathHints`; Windows relies on the system PATH (npm's global bin is in PATH by default after `npm i -g @github/copilot`).

## Test plan

- [x] Backend appears in Settings → CLI backend dropdown
- [ ] Selecting "GitHub Copilot CLI" launches `copilot` in the terminal
- [ ] YOLO mode launches `copilot --allow-all`
- [ ] Resume launches `copilot --continue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)