### PR TITLE
Windows: drop idle CPU spin in terminal_win.py output reader

### DIFF
--- a/terminal_win.py
+++ b/terminal_win.py
@@ -5,12 +5,18 @@ import re
 import threading
 import os
 import msvcrt
-import select
+import time
 
 # Pre-compile regex patterns for performance
 RESIZE_RE = re.compile(rb'\x1b\]RESIZE;[0-9]+;[0-9]+\x07', re.IGNORECASE)
 FOCUS_IN_RE = re.compile(rb'\x1b\[I')
 FOCUS_OUT_RE = re.compile(rb'\x1b\[O')
+
+# pywinpty.PTY.read() is non-blocking on Windows and returns immediately when
+# no data is available. Without a backoff the output reader thread spins at
+# 100% CPU on one core whenever the terminal is idle. 10 ms keeps interactive
+# latency imperceptible while dropping idle CPU to near zero.
+IDLE_SLEEP_S = 0.01
 
 def read_utf8_char(buffer):
     """Read a complete UTF-8 character from buffer, handling multi-byte sequences."""
@@ -81,18 +87,22 @@ def main():
             while running and pty.isalive():
                 try:
                     data = pty.read()
-                    if data:
-                        # pywinpty returns strings
-                        output = data.encode('utf-8') if isinstance(data, str) else data
-                        # Filter out escape sequences that get echoed back
-                        output = RESIZE_RE.sub(b'', output)
-                        output = FOCUS_IN_RE.sub(b'', output)
-                        output = FOCUS_OUT_RE.sub(b'', output)
-                        if output:
-                            sys.stdout.buffer.write(output)
-                            sys.stdout.buffer.flush()
+                    if not data:
+                        time.sleep(IDLE_SLEEP_S)
+                        continue
+                    # pywinpty returns strings
+                    output = data.encode('utf-8') if isinstance(data, str) else data
+                    # Filter out escape sequences that get echoed back
+                    output = RESIZE_RE.sub(b'', output)
+                    output = FOCUS_IN_RE.sub(b'', output)
+                    output = FOCUS_OUT_RE.sub(b'', output)
+                    if output:
+                        sys.stdout.buffer.write(output)
+                        sys.stdout.buffer.flush()
                 except Exception:
-                    pass
+                    # Avoid a tight failure loop if something is persistently
+                    # wrong; pty.isalive() will normally drop us out shortly.
+                    time.sleep(IDLE_SLEEP_S)
             running = False
 
         output_thread = threading.Thread(target=read_output, daemon=True)


### PR DESCRIPTION
## Summary

`terminal_win.py`'s output reader thread spins on a non-blocking `pty.read()` with no backoff. pywinpty's `read()` returns immediately when no data is available, so each idle wrapper instance pinned ~15% of one CPU core continuously. With multiple sidebar tabs the cost stacks linearly.

Concrete impact on a Lenovo Yoga Slim 7i (8 logical cores): three sidebar tabs idle ⇒ ~45% sustained CPU and ~28W battery discharge (vs. ~8–10W expected for light use).

The macOS/Linux `terminal_pty.py` already does this correctly via `select.select(..., timeout=0.05)`; the Windows version simply lacked an equivalent.

## Change

- Sleep 10 ms when `pty.read()` returns empty.
- Same sleep on the rare exception path so a persistent failure cannot become a tight failure loop. (`pty.isalive()` will normally drop the loop out shortly anyway.)
- Drop the unused `import select` (no-op on Windows).

No external dependencies; no new public surface.

## Measurements

Idle CPU per wrapper, measured live inside Obsidian with two sidebar tabs open and idle:

| | per wrapper |
|---|---|
| Before | ~15% of one core |
| After  | 0.3 – 0.9% of one core |

15–50× reduction.

## Test plan

- [x] Python syntax check
- [x] Module import smoke test
- [x] Patched script measured in isolation: 0.08% across 8 cores idle (5 s sample, stdin held open)
- [x] Patched plugin loaded into Obsidian, two terminal tabs, both wrappers measured idle: see table above
- [x] Closing Obsidian properly tears down the wrappers + their cmd.exe + Claude Code descendants — no orphans observed in normal-shutdown path

🤖 Generated with [Claude Code](https://claude.com/claude-code)