### PR TITLE
Fix Windows auto-launch ignoring per-provider CLI flags

### DIFF
--- a/main.js
+++ b/main.js
@@ -7840,6 +7840,7 @@ var TerminalView = class extends import_obsidian.ItemView {
         if (this.proc && !this.proc.killed) {
           let winCmd = backend.binary;
           if (yoloMode && backend.yoloFlag) winCmd += ' ' + backend.yoloFlag;
+          if (additionalFlags) winCmd += ' ' + additionalFlags;
           this.proc.stdin?.write(winCmd + '\r');
         }
       }, 1000);


### PR DESCRIPTION
Problem: On Windows, the CLI Flags setting (per-provider additional flags, e.g. --model claude-opus-4) is silently ignored. The Linux/macOS path appends `additionalFlags` to the command, but the Windows path does not.

Fix: One line added to the Windows auto-launch branch in startShell(), matching the existing Linux/macOS logic.

Testing:
1. Set CLI Flags to `--model claude-opus-4` in sidebar settings
2. Open a new terminal session
3. Confirm Claude Code starts with flags applied