### PR TITLE
Add Ctrl+Shift+C/V copy/paste on Linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -7486,6 +7486,35 @@ var TerminalView = class extends import_obsidian.ItemView {
           }
           return true;
         }
+        // Ctrl+Shift+C / Ctrl+Shift+V: standard Linux terminal copy/paste (GNOME Terminal,
+        // KDE Konsole, most VTE terminals). Plain Ctrl+C/Ctrl+V stay reserved for control
+        // codes (Ctrl+C = SIGINT), so Linux adds Shift to disambiguate. Additive and harmless
+        // elsewhere: macOS uses Cmd+C/V and Windows Ctrl+C/V, both handled below. Uses the
+        // Electron clipboard like the right-click menu and the #89 Ctrl+C fix (the async
+        // Clipboard API can reject silently in the renderer). ev.code so the Shift-uppercased
+        // key letter is irrelevant.
+        if (ev.code === 'KeyC' && ev.ctrlKey && ev.shiftKey && !ev.altKey && !ev.metaKey) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          const selection = this.term.getSelection();
+          if (selection) {
+            try { require("electron").clipboard.writeText(selection); }
+            catch (_) { navigator.clipboard?.writeText(selection).catch(() => {}); }
+          }
+          return false;
+        }
+        if (ev.code === 'KeyV' && ev.ctrlKey && ev.shiftKey && !ev.altKey && !ev.metaKey) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          let text = "";
+          try { text = require("electron").clipboard.readText() || ""; } catch (_) {}
+          if (text) {
+            this.term.paste(text);
+          } else {
+            navigator.clipboard?.readText?.().then((t) => { if (t) this.term.paste(t); }).catch(() => {});
+          }
+          return false;
+        }
         // Windows Ctrl+V: paste from clipboard (Obsidian intercepts this before xterm sees it)
         if (ev.key === 'v' && ev.ctrlKey && !ev.shiftKey && !ev.altKey && !ev.metaKey) {
           ev.preventDefault();


### PR DESCRIPTION
## What was wrong
On Linux, the standard terminal copy/paste keys are `Ctrl+Shift+C` / `Ctrl+Shift+V` (plain `Ctrl+C`/`Ctrl+V` are reserved for control codes like SIGINT). The terminal didn't bind them, so Linux users had no keyboard copy/paste matching their muscle memory. The right-click menu and PRIMARY middle-click already exist, but not the standard shortcuts.

This is the default in GNOME Terminal and KDE Konsole:
- https://help.gnome.org/users/gnome-terminal/stable/adv-keyboard-shortcuts.html.en
- https://docs.kde.org/trunk_kf6/en/konsole/konsole/commandreference.html

## What I changed
Added `Ctrl+Shift+C` (copy selection) and `Ctrl+Shift+V` (paste) to the existing terminal-scoped `attachCustomKeyEventHandler` in `TerminalView` (not a global handler). Both go through Electron's clipboard with a `navigator.clipboard` fallback, matching the right-click Copy/Paste menu and the #89 `Ctrl+C` fix (the async Clipboard API can reject silently in the renderer). Uses `ev.code` so Shift uppercasing the key letter doesn't matter.

Additive and platform-safe: it only triggers on `Ctrl+Shift+` and leaves the existing macOS (`Cmd`) and Windows (`Ctrl`) paths untouched. No new settings, no `manifest.json` bump.

## What I tested
- Ubuntu 24.04, GNOME on **Wayland**, Obsidian 1.12.7 (.deb), CLI backend Claude Code 2.1.199.
- `Ctrl+Shift+C` copies the current selection (Shift+drag to select past the app's mouse-reporting mode) to the system clipboard; `Ctrl+Shift+V` pastes.
- Verified in both the sidebar pane and a main-area tab.
- Confirmed plain `Ctrl+C` still sends SIGINT when there's no selection, and existing middle-click PRIMARY paste still works.
