### PR TITLE
Allow macOS dictation to pass through the terminal

### DIFF
--- a/main.js
+++ b/main.js
@@ -7464,6 +7464,15 @@ var TerminalView = class extends import_obsidian.ItemView {
       return false;
     };
     this.term.attachCustomKeyEventHandler((ev) => {
+      // macOS only: let the Fn key (Fn-Fn dictation trigger) and F5 (dedicated Dictation
+      // key on newer keyboards) pass through untouched instead of being sent to the terminal.
+      if (process.platform === 'darwin' && (ev.key === 'Fn' || ev.key === 'F5')) {
+        return false;
+      }
+      // Defer to native IME/dictation composition handling instead of xterm's.
+      if (ev.isComposing) {
+        return false;
+      }
       // Shift+Enter: send Alt+Enter for multi-line input
       // Must block both keydown and keypress events to prevent xterm from sending normal Enter
       if (ev.key === 'Enter' && ev.shiftKey) {


### PR DESCRIPTION
## What was wrong
The terminal's `attachCustomKeyEventHandler` intercepted every keydown, which prevented macOS dictation (Fn-Fn, or the dedicated Dictation/F5 key on newer keyboards) from arming or inserting text into the Claude sidebar terminal.

## What I changed
Added an early, macOS-only guard that lets the Fn key and F5 pass through untouched instead of being consumed by xterm, plus a guard that defers to native IME/dictation composition handling instead of xterm's when `isComposing` is true

Note: I've also made the code intercept the minimum keys on macOS to limit size of change to as small as possible 

## What I tested it on
- macOS 26.1
- Claude Code CLI backend
- Sidebar pane and a main-area tab (both work)
- Regression: normal typing, Shift+Enter multi-line