### PR TITLE
Fix terminal crash on workspace restore (Linux)

### DIFF
--- a/main.js
+++ b/main.js
@@ -6840,6 +6840,24 @@ var TerminalView = class extends import_obsidian.ItemView {
     return state;
   }
   async onOpen() {
+    // Workspace-restore on startup: the sidebar layout isn't settled yet, and
+    // building xterm now trips Obsidian's `recomputeChildrenDimensions` error in
+    // updateLayout, which tears the view back down (close -> unload throws
+    // "reading 'e'") and can abort app load on Linux. Defer the real init until
+    // onLayoutReady so a persisted terminal reopens on startup without crashing.
+    if (!this.plugin.layoutReady && !this._deferredOpen) {
+      this._deferredOpen = true;
+      this.app.workspace.onLayoutReady(() => {
+        setTimeout(() => {
+          try {
+            this.onOpen();
+          } catch (err) {
+            console.error("[Claude Sidebar] Deferred terminal init failed:", err);
+          }
+        }, 50);
+      });
+      return;
+    }
     try {
       // If terminal is still alive from a prior onOpen, just reattach and focus.
       // Obsidian calls onOpen() each time the view becomes visible; without this


### PR DESCRIPTION
## What was wrong

A Claude terminal left open when quitting is saved into `workspace.json`. On the next launch, restoring that leaf crashed Obsidian:

```
Uncaught TypeError: n.pop(...).recomputeChildrenDimensions is not a function
    at t.updateLayout (app.js)
TypeError: Cannot read properties of undefined (reading 'e')
    at TerminalView.unload
    at TerminalView.close
```

`TerminalView.onOpen` builds xterm immediately. During startup workspace-restore the sidebar layout isn't settled yet, so mounting xterm mid-restore trips Obsidian's `recomputeChildrenDimensions` error in `updateLayout`. That tears the leaf back down (`close -> unload`), where the half-initialized view throws `reading 'e'`, and the uncaught error escalates to the full "An error occurred while loading Obsidian" screen — a persistent crash loop until the leaf is manually removed from `workspace.json`.

This is the "workspace state restore / `TerminalView.unload` on layout restore" bug class called out in `CLAUDE.md`. The existing `onOpen` has a Windows-only guard for the same `recomputeChildrenDimensions` symptom; on Linux it's fatal.

## What changed

When `onOpen` runs during startup restore (`plugin.layoutReady` still false), defer the real init until `onLayoutReady`, then re-enter `onOpen`. The view mounts as an empty container during restore — no xterm, no dimension recompute, no teardown — and the terminal spins up once the layout has settled. Normal (post-startup) opens are unchanged: `layoutReady` is already true, so they take the existing path.

Single change in `TerminalView.onOpen`; no new settings, no `manifest.json` bump.

## Tested on

- **OS:** Linux (NixOS), Obsidian 1.12.7 (installer 1.12.7), X11
- **CLI backend:** Claude Code
- **Plugin:** 1.8.13, manual install
- Repro before fix: open a Claude terminal in the right sidebar → quit → relaunch → fatal load crash, every time.
- After fix: same steps → Obsidian loads and the Claude terminal **restores** in the sidebar, no crash. Verified across several quit/relaunch cycles. Also confirmed opening a fresh terminal post-startup still works (sidebar pane).

Note: I don't have a Windows/macOS box to check those paths, but the deferral only engages during startup restore and is a strict superset of the prior behavior (it just delays init to `onLayoutReady` in that one window).