### PR TITLE
Fix popped-out terminal not re-fitting/rendering when maximized (#94)

### DIFF
--- a/main.js
+++ b/main.js
@@ -7585,10 +7585,43 @@ var TerminalView = class extends import_obsidian.ItemView {
     });
     this.ensureFitWithRetry();
     this.resizeObserver = new ResizeObserver(() => {
-      if (this._fitInProgress) return;
+      // Don't drop a resize that lands mid-fit — remember it so fit()'s release
+      // handler reprocesses it. Otherwise a maximize/restore whose single resize
+      // event coincides with an in-progress fit leaves the terminal at the old
+      // grid (stale/"squished" text — see #94).
+      if (this._fitInProgress) { this._pendingResize = true; return; }
       this.debouncedFit();
     });
     this.resizeObserver.observe(this.termHost);
+    // Keep the terminal fitted and rendering in popped-out windows (#94).
+    // Two Chromium behaviors bite a maximized popout that occludes the main window:
+    //   1) the occluded main window's timers/rAF are throttled, and the plugin's
+    //      code + xterm both schedule work there;
+    //   2) a ResizeObserver doesn't reliably deliver OS window-state changes.
+    // This loop runs on the TERMINAL'S OWN window (resolved every tick, so it
+    // follows the leaf across windows and is never throttled) and each tick:
+    //   - rebinds xterm's renderer to the current window via the CoreBrowserService
+    //     .window setter, so paints run on the active window instead of the
+    //     occluded main window (xterm otherwise stops repainting while you type);
+    //   - re-fits if the grid diverges from what the window can hold.
+    const reconcile = () => {
+      if (this._isDisposed) return;
+      const ownWin = this.termHost?.ownerDocument?.defaultView || window;
+      try {
+        const cbs = this.term?._core?._coreBrowserService;
+        if (cbs && cbs.window !== ownWin) cbs.window = ownWin;
+      } catch (e) {}
+      try {
+        if (this.term && this.fitAddon && !this._fitInProgress) {
+          const dim = this.fitAddon.proposeDimensions();
+          if (dim && dim.cols > 0 && dim.rows > 0 && (dim.cols !== this.term.cols || dim.rows !== this.term.rows)) {
+            this.debouncedFit();
+          }
+        }
+      } catch (e) {}
+      this._reconcileTimer = ownWin.setTimeout(reconcile, 400);
+    };
+    this._reconcileTimer = (this.termHost?.ownerDocument?.defaultView || window).setTimeout(reconcile, 400);
     // Track user scroll intent so auto-scroll doesn't fight the user
     this.userScrolledAt = 0;
     this.termHost.addEventListener("wheel", () => {
@@ -7648,14 +7681,26 @@ var TerminalView = class extends import_obsidian.ItemView {
       }
     } catch (e) {}
     // Release on the frame after next so any ResizeObserver callbacks
-    // caused by this fit() are swallowed instead of re-entering.
-    requestAnimationFrame(() => requestAnimationFrame(() => {
+    // caused by this fit() are swallowed instead of re-entering. Use the
+    // terminal's OWN window: in a popout that occludes the main window, the main
+    // window's rAF is halted, which would strand this flag `true` and make the
+    // ResizeObserver ignore all later resizes (#94). The setTimeout is a safety net.
+    const relWin = this.termHost?.ownerDocument?.defaultView || window;
+    const release = () => {
+      if (this._fitInProgress === false) return;
       this._fitInProgress = false;
-    }));
+      // Reprocess a resize the ResizeObserver dropped while a fit was in progress.
+      if (this._pendingResize) { this._pendingResize = false; this.debouncedFit(); }
+    };
+    relWin.requestAnimationFrame(() => relWin.requestAnimationFrame(release));
+    relWin.setTimeout(release, 250);
   }
   debouncedFit() {
-    if (this.fitTimeout) clearTimeout(this.fitTimeout);
-    this.fitTimeout = setTimeout(() => {
+    // Schedule on the terminal's OWN window: main-window timers are throttled when
+    // a maximized popout occludes the main window, otherwise delaying the fit (#94).
+    const ownWin = this.termHost?.ownerDocument?.defaultView || window;
+    if (this.fitTimeout) { try { ownWin.clearTimeout(this.fitTimeout); } catch (e) {} clearTimeout(this.fitTimeout); }
+    this.fitTimeout = ownWin.setTimeout(() => {
       this.fitTimeout = null;
       if (!this.term || !this.fitAddon) return;
       const dim = this.fitAddon.proposeDimensions();
@@ -7932,6 +7977,12 @@ var TerminalView = class extends import_obsidian.ItemView {
     this.plugin?._trackedTerminalViews?.delete(this);
     this.resizeObserver?.disconnect();
     this.themeObserver?.disconnect();
+    if (this._reconcileTimer) {
+      // Loop also self-stops via the _isDisposed check; clear best-effort.
+      try { (this.termHost?.ownerDocument?.defaultView || window).clearTimeout(this._reconcileTimer); } catch (e) {}
+      clearTimeout(this._reconcileTimer);
+      this._reconcileTimer = null;
+    }
     if (this.fitTimeout) {
       clearTimeout(this.fitTimeout);
       this.fitTimeout = null;

--- a/main.js
+++ b/main.js
@@ -7593,35 +7593,6 @@ var TerminalView = class extends import_obsidian.ItemView {
       this.debouncedFit();
     });
     this.resizeObserver.observe(this.termHost);
-    // Keep the terminal fitted and rendering in popped-out windows (#94).
-    // Two Chromium behaviors bite a maximized popout that occludes the main window:
-    //   1) the occluded main window's timers/rAF are throttled, and the plugin's
-    //      code + xterm both schedule work there;
-    //   2) a ResizeObserver doesn't reliably deliver OS window-state changes.
-    // This loop runs on the TERMINAL'S OWN window (resolved every tick, so it
-    // follows the leaf across windows and is never throttled) and each tick:
-    //   - rebinds xterm's renderer to the current window via the CoreBrowserService
-    //     .window setter, so paints run on the active window instead of the
-    //     occluded main window (xterm otherwise stops repainting while you type);
-    //   - re-fits if the grid diverges from what the window can hold.
-    const reconcile = () => {
-      if (this._isDisposed) return;
-      const ownWin = this.termHost?.ownerDocument?.defaultView || window;
-      try {
-        const cbs = this.term?._core?._coreBrowserService;
-        if (cbs && cbs.window !== ownWin) cbs.window = ownWin;
-      } catch (e) {}
-      try {
-        if (this.term && this.fitAddon && !this._fitInProgress) {
-          const dim = this.fitAddon.proposeDimensions();
-          if (dim && dim.cols > 0 && dim.rows > 0 && (dim.cols !== this.term.cols || dim.rows !== this.term.rows)) {
-            this.debouncedFit();
-          }
-        }
-      } catch (e) {}
-      this._reconcileTimer = ownWin.setTimeout(reconcile, 400);
-    };
-    this._reconcileTimer = (this.termHost?.ownerDocument?.defaultView || window).setTimeout(reconcile, 400);
     // Track user scroll intent so auto-scroll doesn't fight the user
     this.userScrolledAt = 0;
     this.termHost.addEventListener("wheel", () => {
@@ -7665,6 +7636,11 @@ var TerminalView = class extends import_obsidian.ItemView {
     if (!this.term || !this.fitAddon) return;
     if (this._fitInProgress) return;
     this._fitInProgress = true;
+    // Tie the release to THIS fit. Both release paths below (rAF chain + setTimeout
+    // safety net) capture `gen`; a later fit bumps _fitGen, so a stale release from
+    // an earlier fit can't clear a newer fit's flag mid-fit (which would re-open the
+    // re-entrant fit loop from #80). See PR #94 review.
+    const gen = this._fitGen = (this._fitGen || 0) + 1;
     try {
       const userScrolled = Date.now() - (this.userScrolledAt || 0) < 5000;
       const wasAtBottom = !userScrolled && this.term.buffer.active.baseY === this.term.buffer.active.viewportY;
@@ -7687,27 +7663,74 @@ var TerminalView = class extends import_obsidian.ItemView {
     // ResizeObserver ignore all later resizes (#94). The setTimeout is a safety net.
     const relWin = this.termHost?.ownerDocument?.defaultView || window;
     const release = () => {
-      if (this._fitInProgress === false) return;
+      if (gen !== this._fitGen || this._fitInProgress === false) return;
       this._fitInProgress = false;
       // Reprocess a resize the ResizeObserver dropped while a fit was in progress.
       if (this._pendingResize) { this._pendingResize = false; this.debouncedFit(); }
     };
     relWin.requestAnimationFrame(() => relWin.requestAnimationFrame(release));
-    relWin.setTimeout(release, 250);
+    this._relTimeoutWin = relWin;
+    this._relTimeout = relWin.setTimeout(release, 250);
   }
   debouncedFit() {
     // Schedule on the terminal's OWN window: main-window timers are throttled when
-    // a maximized popout occludes the main window, otherwise delaying the fit (#94).
+    // a maximized popout occludes the main window, which would otherwise delay the
+    // fit (#94). Clear the pending timer on the window that created it — timer IDs
+    // are per-window small integers, so clearing a popout-minted id on the main
+    // window would likely cancel an unrelated main-window timer.
     const ownWin = this.termHost?.ownerDocument?.defaultView || window;
-    if (this.fitTimeout) { try { ownWin.clearTimeout(this.fitTimeout); } catch (e) {} clearTimeout(this.fitTimeout); }
+    if (this.fitTimeout) this._fitTimeoutWin?.clearTimeout(this.fitTimeout);
+    this._fitTimeoutWin = ownWin;
     this.fitTimeout = ownWin.setTimeout(() => {
       this.fitTimeout = null;
       if (!this.term || !this.fitAddon) return;
+      // Keep xterm's renderer bound to the window the terminal is actually shown in.
+      // On an already-open terminal, Terminal.open() does nothing but rebind
+      // CoreBrowserService.window (no DOM work) — the supported way to move a
+      // terminal between windows. Without it a popped-out terminal keeps painting on
+      // the main window's rAF and stops repainting once the maximized popout occludes
+      // that window (#94). Runs here because onLayoutChange (popout) and the
+      // ResizeObserver (maximize) both route through debouncedFit.
+      try { this.term.open(this.termHost); } catch (e) {}
+      // Ensure the popout poll is running (started here, where the terminal's
+      // window is correctly resolved — at onLayoutChange time the leaf may not
+      // have moved into the popout yet). No-op when docked or already running.
+      this._ensurePopoutReconcile();
       const dim = this.fitAddon.proposeDimensions();
       if (!dim || dim.cols <= 0 || dim.rows <= 0) return;
       if (dim.cols === this.term.cols && dim.rows === this.term.rows) return;
       this.fit();
     }, 100);
+  }
+  // Poll-reconcile the fit ONLY while the terminal is popped out (#94 review).
+  // A docked terminal relies on the ResizeObserver + onLayoutChange, which are
+  // reliable when the window isn't occluded — so no poll cost in the common case.
+  // A popped-out window, once maximized, occludes the main window: its timers/rAF
+  // are throttled AND the ResizeObserver doesn't reliably deliver the maximize, so
+  // the grid can strand. The poll runs on the popout's OWN clock (active, not
+  // throttled), re-fits on divergence, and self-stops the moment the leaf re-docks.
+  _ensurePopoutReconcile() {
+    if (this._reconcileTimer || this._isDisposed) return;
+    const isPopout = () => (this.termHost?.ownerDocument?.defaultView || window) !== window;
+    if (!isPopout()) return;
+    const tick = () => {
+      this._reconcileTimer = null;
+      if (this._isDisposed || !isPopout()) return; // re-docked → stop polling
+      const w = this.termHost.ownerDocument.defaultView;
+      try {
+        if (this.term && this.fitAddon && !this._fitInProgress) {
+          const dim = this.fitAddon.proposeDimensions();
+          if (dim && dim.cols > 0 && dim.rows > 0 && (dim.cols !== this.term.cols || dim.rows !== this.term.rows)) {
+            this.debouncedFit();
+          }
+        }
+      } catch (e) {}
+      this._reconcileTimerWin = w;
+      this._reconcileTimer = w.setTimeout(tick, 400);
+    };
+    const w = this.termHost.ownerDocument.defaultView;
+    this._reconcileTimerWin = w;
+    this._reconcileTimer = w.setTimeout(tick, 400);
   }
   async waitForHostReady() {
     if (!this.fitAddon)
@@ -7977,15 +8000,20 @@ var TerminalView = class extends import_obsidian.ItemView {
     this.plugin?._trackedTerminalViews?.delete(this);
     this.resizeObserver?.disconnect();
     this.themeObserver?.disconnect();
-    if (this._reconcileTimer) {
-      // Loop also self-stops via the _isDisposed check; clear best-effort.
-      try { (this.termHost?.ownerDocument?.defaultView || window).clearTimeout(this._reconcileTimer); } catch (e) {}
-      clearTimeout(this._reconcileTimer);
-      this._reconcileTimer = null;
-    }
+    // Clear pending timers on the window that created them (they may be
+    // popout-minted; a bare clearTimeout would run on the main window and could
+    // cancel an unrelated timer that happens to share the id — see #94 review).
     if (this.fitTimeout) {
-      clearTimeout(this.fitTimeout);
+      (this._fitTimeoutWin || window).clearTimeout(this.fitTimeout);
       this.fitTimeout = null;
+    }
+    if (this._relTimeout) {
+      (this._relTimeoutWin || window).clearTimeout(this._relTimeout);
+      this._relTimeout = null;
+    }
+    if (this._reconcileTimer) {
+      (this._reconcileTimerWin || window).clearTimeout(this._reconcileTimer);
+      this._reconcileTimer = null;
     }
     if (this.ctrlOFocusIn) {
       this.containerEl.removeEventListener('focusin', this.ctrlOFocusIn);


### PR DESCRIPTION
Fixes #94.

## What was wrong
In a popped-out Claude window, maximizing it makes the terminal (1) keep its old, smaller grid ("squished" text that doesn't reflow) and (2) lag badly while typing. Drag-resize is fine; restoring to a small window clears it.

Root cause: Chromium throttles rAF/timers for an **occluded** window. A maximized popout occludes the main Obsidian window, and both the plugin and xterm scheduled work there:
- `fit()` released `_fitInProgress` via the main window's rAF (stranded `true` when occluded → the `ResizeObserver` then dropped every resize via `if (this._fitInProgress) return;`), and `debouncedFit()`'s `setTimeout` ran on the throttled main-window clock (re-fit stalled).
- xterm paints via rAF on `CoreBrowserService.window`, fixed at `open()` time to the main window (the tab starts in the sidebar), so after popout it kept painting on the occluded main window and stopped repainting entirely while typing.

## What changed (`main.js`, `TerminalView`)
- Schedule fit work (`fit()`'s flag release + `debouncedFit`) on the terminal's own window (`termHost.ownerDocument.defaultView`), not the main window.
- Coalesce a resize dropped mid-fit (`_pendingResize`) and reprocess it on release.
- Reconcile loop on the own window that rebinds `term._core._coreBrowserService.window` to the current window and re-fits on grid divergence; cleared on dispose.

No `manifest.json` bump. One file, +57/−6.

## Tested on
Windows 11, Obsidian 1.12.7 (Claude Code backend): popped-out maximize/restore now reflows within ~1s and repaints track keystrokes 1:1 (verified via instrumentation — xterm `onRender` went from 0/s while typing maximized to matching keystrokes). Sidebar, main-area tab, small popout, and drag-resize behavior unchanged.
