### PR TITLE
Per-tab CLI provider: open a tab on another CLI without changing the default

### DIFF
--- a/main.js
+++ b/main.js
@@ -6801,15 +6801,25 @@ var TerminalView = class extends import_obsidian.ItemView {
     this.workingDir = null;
     // YOLO mode (--dangerously-skip-permissions)
     this.yoloMode = false;
+    // Per-tab CLI provider override. null = follow the default in settings.
+    this.backendKey = null;
+  }
+  getBackendKey() {
+    const key = this.backendKey || this.plugin.pluginData.cliBackend || "claude";
+    return CLI_BACKENDS[key] ? key : "claude";
   }
   getBackend() {
-    const key = this.plugin.pluginData.cliBackend || "claude";
-    return CLI_BACKENDS[key] || CLI_BACKENDS.claude;
+    return CLI_BACKENDS[this.getBackendKey()];
   }
   getViewType() {
     return VIEW_TYPE;
   }
   getDisplayText() {
+    // Only override-tabs get a provider-specific title, so the default tab name
+    // stays stable for everyone who never touches the per-tab switcher.
+    if (this.backendKey && CLI_BACKENDS[this.backendKey]) {
+      return CLI_BACKENDS[this.backendKey].label;
+    }
     return "Claude";
   }
   getIcon() {
@@ -6827,8 +6837,11 @@ var TerminalView = class extends import_obsidian.ItemView {
     if (state?.continueSession) {
       this.continueSession = state.continueSession;
     }
+    if (state?.backendKey && CLI_BACKENDS[state.backendKey]) {
+      this.backendKey = state.backendKey;
+    }
     // If shell already started, restart with new settings
-    if (this.proc && (state?.workingDir || state?.yoloMode || state?.continueSession)) {
+    if (this.proc && (state?.workingDir || state?.yoloMode || state?.continueSession || state?.backendKey)) {
       this.startShell(this.workingDir, this.yoloMode, this.continueSession);
     }
   }
@@ -6836,6 +6849,8 @@ var TerminalView = class extends import_obsidian.ItemView {
     const state = {};
     if (this.workingDir) state.workingDir = this.workingDir;
     if (this.yoloMode) state.yoloMode = this.yoloMode;
+    // Persisted so a one-off provider tab comes back as that provider on restore
+    if (this.backendKey) state.backendKey = this.backendKey;
     // Don't persist continueSession — it's a one-time action
     return state;
   }
@@ -7812,8 +7827,8 @@ var TerminalView = class extends import_obsidian.ItemView {
         cmd = "python";
       }
     }
-    const backend = this.getBackend();
-    const backendKey = this.plugin.pluginData.cliBackend || "claude";
+    const backendKey = this.getBackendKey();
+    const backend = CLI_BACKENDS[backendKey];
     let cliCmd = backend.binary;
     if (yoloMode && backend.yoloFlag) cliCmd += " " + backend.yoloFlag;
     const flagsByProvider = this.plugin.pluginData.flagsByProvider || {};
@@ -8067,11 +8082,14 @@ var TerminalView = class extends import_obsidian.ItemView {
     this.fitAddon = null;
   }
 };
+// mode "default": change the saved default provider, then open a tab with it.
+// mode "once":    open a tab with the chosen provider and leave the default alone.
 var CliProviderSwitchModal = class extends import_obsidian.SuggestModal {
-  constructor(app, plugin) {
+  constructor(app, plugin, mode = "default") {
     super(app);
     this.plugin = plugin;
-    this.setPlaceholder("Switch CLI provider…");
+    this.mode = mode;
+    this.setPlaceholder(mode === "once" ? "Open a tab with…" : "Switch default CLI provider…");
   }
   getSuggestions(query) {
     const q = query.toLowerCase();
@@ -8081,10 +8099,17 @@ var CliProviderSwitchModal = class extends import_obsidian.SuggestModal {
       .filter(({ backend }) => backend.label.toLowerCase().includes(q) || backend.binary.toLowerCase().includes(q));
   }
   renderSuggestion(item, el) {
-    el.createEl("div", { text: item.backend.label + (item.isCurrent ? "  (current)" : "") });
+    const suffix = item.isCurrent ? (this.mode === "once" ? "  (default)" : "  (current)") : "";
+    el.createEl("div", { text: item.backend.label + suffix });
     el.createEl("small", { text: item.backend.binary, cls: "vault-terminal-suggest-binary" });
   }
   async onChooseSuggestion(item) {
+    if (this.mode === "once") {
+      // Pass the key explicitly even when it matches the default, so the tab
+      // keeps running that provider if the default changes later.
+      this.plugin.createNewTab(null, false, false, item.key);
+      return;
+    }
     this.plugin.pluginData.cliBackend = item.key;
     await this.plugin.saveData(this.plugin.pluginData);
     this.plugin.createNewTab();
@@ -8291,8 +8316,13 @@ var VaultTerminalPlugin = class extends import_obsidian.Plugin {
     });
     this.addCommand({
       id: "switch-cli-provider",
-      name: "Switch CLI provider…",
-      callback: () => new CliProviderSwitchModal(this.app, this).open()
+      name: "Switch default CLI provider…",
+      callback: () => new CliProviderSwitchModal(this.app, this, "default").open()
+    });
+    this.addCommand({
+      id: "new-tab-with-cli-provider",
+      name: "New Tab (other CLI)…",
+      callback: () => new CliProviderSwitchModal(this.app, this, "once").open()
     });
     this.addCommand({
       id: "new-claude-tab",
@@ -8524,7 +8554,7 @@ var VaultTerminalPlugin = class extends import_obsidian.Plugin {
     }
     await this.createNewTab();
   }
-  async createNewTab(workingDir = null, yoloMode = false, continueSession = false) {
+  async createNewTab(workingDir = null, yoloMode = false, continueSession = false, backendKey = null) {
     if (!this.layoutReady) return;
     const leaf = this.app.workspace.getRightLeaf(false);
     if (leaf) {
@@ -8532,6 +8562,7 @@ var VaultTerminalPlugin = class extends import_obsidian.Plugin {
       if (workingDir) state.workingDir = workingDir;
       if (yoloMode) state.yoloMode = yoloMode;
       if (continueSession) state.continueSession = continueSession;
+      if (backendKey) state.backendKey = backendKey;
       await leaf.setViewState({
         type: VIEW_TYPE,
         active: true,


### PR DESCRIPTION
Switching providers rewrote the saved default, so running Codex for one task meant switching back afterward. This adds a second command that opens a tab on the chosen provider and leaves the default alone. No new settings.

- `Switch default CLI provider…` — same behavior, renamed for contrast. ID unchanged, hotkeys still bind.
- `New Tab (other CLI)…` — new. #98 renames it to `New agent tab (other CLI)…`.

`TerminalView` gets a `backendKey`; null means follow the default. `getBackendKey()` resolves override → default → `claude`. The override rides through `setViewState` and persists in `getState()`, so a one-off tab survives a restart. It's passed explicitly even when it matches the current default, so changing the default later doesn't move a running tab. Per-provider CLI flags follow the tab, not the default. Override tabs use the provider label as their title.

**Left out:** `New Tab (YOLO mode)` and `Resume last conversation` still key off the default provider — from a one-off Codex tab they open a tab on the default. Separate change.

**Tested** — macOS 26.5, Obsidian 1.13.4, live instance driven by a harness plugin in a scratch vault:

- One-off Codex tab spawns the real binary — `ps` shows `zsh -lc codex` under the PTY wrapper.
- `data.json` afterward holds only `lastCwd`. No `cliBackend` written.
- A plain tab opened alongside followed the default, not the Codex neighbor.
- With the default moved to `opencode`, the saved layout carried `{"backendKey": "codex"}`; the tab restored as "Codex" and relaunched `codex`.

No PTY, process, or layout code touched, so Windows and Linux are unaffected.