### PR TITLE
feat: make http/https URLs clickable in the terminal

### DIFF
--- a/main.js
+++ b/main.js
@@ -7347,6 +7347,28 @@ var TerminalView = class extends import_obsidian.ItemView {
         callback(links.length ? links : void 0);
       }
     });
+    this.term.registerLinkProvider?.({
+      provideLinks: (y, callback) => {
+        const line = this.term?.buffer.active.getLine(y - 1);
+        if (!line) return callback(void 0);
+        const text = line.translateToString(true);
+        const links = [];
+        const reUrl = /https?:\/\/[^\s\x00-\x1f"'<>()\[\]{}\\^`|]+/g;
+        let m;
+        while ((m = reUrl.exec(text)) !== null) {
+          const url = m[0].replace(/[.,;:!?]+$/, "");
+          links.push({
+            text: url,
+            range: { start: { x: m.index + 1, y }, end: { x: m.index + url.length, y } },
+            activate: () => {
+              try { require("electron").shell.openExternal(url); }
+              catch (_) { window.open(url, "_blank"); }
+            }
+          });
+        }
+        callback(links.length ? links : void 0);
+      }
+    });
     // Handle image paste - use capture phase to intercept before xterm's textarea
     this.imagePasteHandler = async (e) => {
       // Only handle if terminal has focus

--- a/main.js
+++ b/main.js
@@ -7353,10 +7353,23 @@ var TerminalView = class extends import_obsidian.ItemView {
         if (!line) return callback(void 0);
         const text = line.translateToString(true);
         const links = [];
-        const reUrl = /https?:\/\/[^\s\x00-\x1f"'<>()\[\]{}\\^`|]+/g;
+        // Match http(s) URLs. Surrounding quotes (ASCII or curly) do not prevent a
+        // match — the scheme anchor starts inside them. Trailing closers/punctuation
+        // are trimmed after the match so wiki-style paths with parens still work.
+        const reUrl = /https?:\/\/[^\s\x00-\x1f<>]+/g;
         let m;
         while ((m = reUrl.exec(text)) !== null) {
-          const url = m[0].replace(/[.,;:!?]+$/, "");
+          let url = m[0];
+          // Strip trailing sentence punctuation
+          url = url.replace(/[.,;:!?]+$/u, "");
+          // Strip trailing quotes / brackets / braces / backticks (not parens —
+          // parens are handled below so wiki Foo_(bar) stays intact)
+          url = url.replace(/["'\]\}>`\u201d\u2019\u00bb]+$/u, "");
+          // Peel trailing ')' only while still unbalanced
+          while (url.endsWith(")") && (url.match(/\(/g) || []).length < (url.match(/\)/g) || []).length) {
+            url = url.slice(0, -1);
+          }
+          if (!/^https?:\/\/.+/.test(url)) continue;
           links.push({
             text: url,
             range: { start: { x: m.index + 1, y }, end: { x: m.index + url.length, y } },


### PR DESCRIPTION
## Summary

- Registers a second xterm `registerLinkProvider` that detects `http://` and `https://` URLs on each terminal line
- Opens them via `electron.shell.openExternal` (with a `window.open` fallback for non-Electron contexts)
- Strips trailing punctuation (`.`, `,`, `;`, `:`, `!`, `?`) to avoid broken URLs at sentence ends
- Mirrors the existing vault-path link provider pattern already in the plugin — no new dependencies required

## Motivation

When agent output (e.g. Claude Code responses) contains URLs, they currently appear as plain unclickable text. This change makes them Cmd/Ctrl-clickable just like vault file paths already are.

## Test plan

- [ ] Run the plugin in Obsidian with an agent that outputs a URL in the terminal
- [ ] Hover over the URL — it should be underlined/highlighted as a link
- [ ] Click it — it should open in the system browser
- [ ] Verify vault file path links still work as before
- [ ] Verify URLs with trailing punctuation (e.g. `https://example.com.`) open correctly without the trailing dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)